### PR TITLE
refactor: drop the IIFE bundle, ship ESM only

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Email validation compatible with PHP's `filter_var($value, FILTER_VALIDATE_EMAIL
 > - **ESM package** — there is no separate CommonJS build. `import` works everywhere; `require()` works on Node.js >= 22.12 via native `require(ESM)`.
 > - **Node.js >= 22** required.
 > - Only the package root is exported; deep imports (e.g. `filter-validate-email/es/...`) are no longer available.
-> - The browser bundle is the minified IIFE at `dist/filter-validate-email.min.js` (unminified/UMD/AMD builds were dropped).
+> - In the browser, load it as an ES module from a CDN (`<script type="module">`, see below); there is no bundled browser global / UMD / IIFE build.
 >
-> If you need a real CommonJS build or older runtimes, stay on [v1](https://www.npmjs.com/package/filter-validate-email/v/1.1.3).
+> If you need a real CommonJS build, a browser global, or older runtimes, stay on [v1](https://www.npmjs.com/package/filter-validate-email/v/1.1.3).
 
 # Installing
 
@@ -22,15 +22,19 @@ npm install filter-validate-email
 
 ## CDN
 
+Load it as an ES module from any npm CDN:
+
 ```html
-<script src="https://unpkg.com/filter-validate-email@latest/dist/filter-validate-email.min.js"></script>
-<script>
-  // exposed as the global `FilterValidateEmail`
-  FilterValidateEmail.default('...');
+<script type="module">
+  import validateEmail from 'https://esm.sh/filter-validate-email';
+
+  validateEmail('...'); // true / false
 </script>
 ```
 
-It is strongly recommended that you replace `latest` with a fixed version.
+jsDelivr (`https://cdn.jsdelivr.net/npm/filter-validate-email/+esm`) and unpkg (`https://unpkg.com/filter-validate-email?module`) work too.
+
+It is strongly recommended that you pin a fixed version, e.g. `https://esm.sh/filter-validate-email@2.0.0`.
 
 # Usage
 

--- a/package.json
+++ b/package.json
@@ -13,8 +13,6 @@
   },
   "types": "./dist/index.d.ts",
   "module": "./dist/index.js",
-  "unpkg": "./dist/filter-validate-email.min.js",
-  "jsdelivr": "./dist/filter-validate-email.min.js",
   "files": [
     "dist"
   ],
@@ -29,7 +27,6 @@
     "fix:eslint": "eslint . --fix",
     "fix:prettier": "prettier . --write",
     "fix": "npm run fix:eslint && npm run fix:prettier",
-    "prebuild": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\"",
     "build": "tsup",
     "test": "npm run test:php && npm run test:ts",
     "test:coverage": "npm run test:php && npm run test:ts:coverage",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,27 +1,12 @@
 import { defineConfig } from 'tsup';
 
-// `dist` is wiped by the `prebuild` script, not by tsup's own `clean`, because
-// these two builds run concurrently and a per-config `clean` could race with
-// and delete the other build's freshly written output.
-export default defineConfig([
-  // ESM build (+ type declarations) for npm consumers / bundlers
-  {
-    entry: ['src/index.ts'],
-    format: ['esm'],
-    dts: true,
-    sourcemap: true,
-    clean: false,
-    target: 'es2020',
-  },
-  // Minified IIFE build exposing a browser global for `<script>` / CDN usage
-  {
-    entry: { 'filter-validate-email': 'src/index.ts' },
-    format: ['iife'],
-    globalName: 'FilterValidateEmail',
-    minify: true,
-    sourcemap: true,
-    clean: false,
-    target: 'es2020',
-    outExtension: () => ({ js: '.min.js' }),
-  },
-]);
+// Single ESM build (+ type declarations). Browsers load it as an ES module
+// straight from a CDN (esm.sh / jsDelivr), so no separate IIFE/UMD bundle.
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: 'es2020',
+});


### PR DESCRIPTION
Now that the package is ESM-only, browsers can load it as an ES module straight from a CDN, so the separate minified IIFE browser-global build is redundant. This removes it and simplifies to a single ESM output.

## Changes
- **tsup**: single ESM (+dts) build. `clean` is handled by tsup itself, so the `prebuild` script and its dual-build clean race are gone.
- **package.json**: drop `unpkg` / `jsdelivr` fields (they pointed at the IIFE).
- **README**: CDN section now uses the modern idiom:
  ```html
  <script type="module">
    import validateEmail from 'https://esm.sh/filter-validate-email';
    validateEmail('...'); // true / false
  </script>
  ```
  This also exposes the default export as a directly-callable `validateEmail(...)` instead of the old `FilterValidateEmail.default(...)` global. jsDelivr `+esm` / unpkg `?module` work too.

## Notes
- No dependency changes — `package-lock.json` is untouched.
- Tarball drops to 6 files (removed `filter-validate-email.min.js` + its map).
- `publint`: **All good!** `attw`: node10 / node16-from-ESM / bundler all 🟢; the single ⚠️ `CJSResolvesToESM` is the intended trade-off of the `default` export condition (require(ESM) interop on Node ≥ 22.12).

## Verification
`check` ✅ / `lint` ✅ / `test:coverage` ✅ (210 passed, 100%) / `build` ✅ (ESM only) / real `npm ci` ✅.