### PR TITLE
ci: publish to npm via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+  id-token: write # required for npm Trusted Publishing (OIDC) + provenance
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,7 +21,8 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
+      # setup-node bundles an older npm; Trusted Publishing needs npm >= 11.5.1
+      - run: npm install -g npm@latest
       - run: npm ci
+      # No NODE_AUTH_TOKEN: auth comes from the OIDC token via Trusted Publishing.
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The v2.0.0 release run failed with `npm error code ENEEDAUTH` — there is no `NPM_TOKEN` secret configured. Rather than add a long-lived token, switch the release workflow to **npm Trusted Publishing (OIDC)** (the npm-side trusted publisher is already configured for this package).

## Changes to `release.yml`
- Add `permissions: id-token: write` (and `contents: read`) so the job can mint an OIDC token.
- `npm install -g npm@latest` — setup-node bundles an older npm; Trusted Publishing needs npm >= 11.5.1.
- Drop `NODE_AUTH_TOKEN` / `secrets.NPM_TOKEN` from `npm publish`.

Auth now comes from the OIDC token exchanged with the trusted publisher on npmjs.org, and **provenance attestation is generated automatically**.

## After merge — to publish v2.0.0
Create/publish the GitHub Release for `v2.0.0` (this triggers the workflow). Since the ESM-only changes (#19) are already on `master`, the published package will be the single-ESM build. npm currently has only `1.1.3`, so there's nothing to clean up.

> Note: this workflow only runs on `release`, so it can't be exercised by PR CI — it's validated on the next release.