### PR TITLE
ci: switch release to workflow_dispatch, publish before tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,10 @@
 name: Node.js Package
 
 on:
-  release:
-    types: [created]
+  workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write # for creating the tag and GitHub Release
   id-token: write # required for npm Trusted Publishing (OIDC) + provenance
 
 jobs:
@@ -24,5 +23,13 @@ jobs:
       # setup-node bundles an older npm; Trusted Publishing needs npm >= 11.5.1
       - run: npm install -g npm@latest
       - run: npm ci
-      # No NODE_AUTH_TOKEN: auth comes from the OIDC token via Trusted Publishing.
+      # 1. Publish the canonical artifact first (no NODE_AUTH_TOKEN: OIDC).
+      #    prepublishOnly runs checks/tests/build before the irreversible publish.
       - run: npm publish
+      # 2. Only after a successful publish, create the tag and GitHub Release
+      - name: Create tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="v$(node -p "require('./package.json').version")"
+          gh release create "$VERSION" --target "$GITHUB_SHA" --generate-notes


### PR DESCRIPTION
## Background

`release.yml` triggered `npm publish` on GitHub Release creation (`on: release: types: [created]`). This is an anti-pattern: if the publish fails, the tag and Release are already finalized. With GitHub's **Immutable Releases**, that tag name can never be reused, so a failed publish burns a version number.

More context (JA): https://zenn.dev/yumemi_inc/articles/github-release-not-a-publish-trigger

## Changes

- Trigger: `release` → **`workflow_dispatch`**
- Order: **`npm publish` (`prepublishOnly` runs check/test/build) → create the tag and GitHub Release only on success**
- Grant `contents: write` (needed to create the tag / Release)
- The version is derived from `package.json`
- OIDC Trusted Publishing is already on `master` (#20); this PR only changes the trigger/order

## Release procedure (after this change)

1. Bump `version` in `package.json` and merge to `master`
2. Run the **Node.js Package** workflow manually from the Actions tab
3. On a successful `npm publish`, the `vX.Y.Z` tag and GitHub Release are created automatically

If the publish fails, no tag or Release is created, so you can retry with the same version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)